### PR TITLE
if firebug is available, dump the contents of the console

### DIFF
--- a/firefox/content/overlay.js
+++ b/firefox/content/overlay.js
@@ -9,9 +9,10 @@ var JSErrorCollector = {
 			for (var i=0; i<this.list.length; ++i) {
 				var scriptError = this.list[i];
 				resp[i] = {
-						errorMessage: scriptError.errorMessage,
-						sourceName: scriptError.sourceName,
-						lineNumber: scriptError.lineNumber
+						errorMessage: scriptError.error.errorMessage,
+						sourceName: scriptError.error.sourceName,
+						lineNumber: scriptError.error.lineNumber,
+						console: scriptError.console
 						};
 			}
 			this.list = [];
@@ -84,7 +85,20 @@ var JSErrorCollector_ErrorConsoleListener =
                 // We're just looking for content JS errors (see https://developer.mozilla.org/en/XPCOM_Interface_Reference/nsIScriptError#Categories)
                 if (errorCategory == "content javascript")
                 {
-                	JSErrorCollector.addError(error);
+            		var err = {
+            			error: error
+            		};
+                	JSErrorCollector.addError(err);
+			try {
+				if (Firebug && Firebug.currentContext) {
+					setTimeout(function() {
+					
+					var doc = Firebug.currentContext.getPanel("console").document;
+					var s = new XMLSerializer();
+					err.console = s.serializeToString(doc);
+					}, 100);
+				}
+			} catch (e) {}
                 }
             }
             catch (exception)

--- a/src/main/java/net/jsourcerer/webdriver/jserrorcollector/JavaScriptError.java
+++ b/src/main/java/net/jsourcerer/webdriver/jserrorcollector/JavaScriptError.java
@@ -20,17 +20,20 @@ public class JavaScriptError {
 	private final String errorMessage;
 	private final String sourceName;
 	private final int lineNumber;	
+	private final String console;
 
 	JavaScriptError(final Map<String, ? extends Object> map) {
 		errorMessage = (String) map.get("errorMessage");
 		sourceName = (String) map.get("sourceName");
 		lineNumber = ((Number) map.get("lineNumber")).intValue();
+		console = (String) map.get("console");
 	}
 
-	JavaScriptError(final String errorMessage, final String sourceName, final int lineNumber) {
+	JavaScriptError(final String errorMessage, final String sourceName, final int lineNumber, String console) {
 		this.errorMessage = errorMessage;
 		this.sourceName = sourceName;
 		this.lineNumber = lineNumber;
+		this.console = console;
 	}
 
 	public String getErrorMessage() {
@@ -43,6 +46,10 @@ public class JavaScriptError {
 	
 	public String getSourceName() {
 		return sourceName;
+	}
+	
+	public String getConsole() {
+		return console;
 	}
 	
 	@Override
@@ -116,5 +123,11 @@ public class JavaScriptError {
 	 */
 	public static void addExtension(final FirefoxProfile ffProfile) throws IOException {
 		ffProfile.addExtension(JavaScriptError.class, "JSErrorCollector.xpi");
+		ffProfile.setPreference("extensions.firebug.showStackTrace", "true");
+		ffProfile.setPreference("extensions.firebug.delayLoad", "false");
+		ffProfile.setPreference("extensions.firebug.showFirstRunPage", "false");
+		ffProfile.setPreference("extensions.firebug.allPagesActivation", "on");
+		ffProfile.setPreference("extensions.firebug.console.enableSites", "true");
+		ffProfile.setPreference("extensions.firebug.defaultPanelName", "console");
 	}
 }

--- a/src/test/java/net/jsourcerer/webdriver/jserrorcollector/SimpleTest.java
+++ b/src/test/java/net/jsourcerer/webdriver/jserrorcollector/SimpleTest.java
@@ -21,18 +21,18 @@ import static org.junit.Assert.assertEquals;
  */
 public class SimpleTest {
 	private final String urlSimpleHtml = getResource("simple.html");
-	private final JavaScriptError errorSimpleHtml = new JavaScriptError("TypeError: null has no properties", urlSimpleHtml, 9);
+	private final JavaScriptError errorSimpleHtml = new JavaScriptError("TypeError: null has no properties", urlSimpleHtml, 9, null);
 	
 	private final String urlWithNestedFrameHtml = getResource("withNestedFrame.html");
-	private final JavaScriptError errorWithNestedFrameHtml = new JavaScriptError("TypeError: \"foo\".notHere is not a function", urlWithNestedFrameHtml, 7);
+	private final JavaScriptError errorWithNestedFrameHtml = new JavaScriptError("TypeError: \"foo\".notHere is not a function", urlWithNestedFrameHtml, 7, null);
 
 	private final String urlWithPopupHtml = getResource("withPopup.html");
 	private final String urlPopupHtml = getResource("popup.html");
-	private final JavaScriptError errorPopupHtml = new JavaScriptError("ReferenceError: error is not defined", urlPopupHtml, 5);
+	private final JavaScriptError errorPopupHtml = new JavaScriptError("ReferenceError: error is not defined", urlPopupHtml, 5, null);
 
 	private final String urlWithExternalJs = getResource("withExternalJs.html");
 	private final String urlExternalJs = getResource("external.js");
-	private final JavaScriptError errorExternalJs = new JavaScriptError("TypeError: document.notExisting is undefined", urlExternalJs, 1);
+	private final JavaScriptError errorExternalJs = new JavaScriptError("TypeError: document.notExisting is undefined", urlExternalJs, 1, null);
 
 	/**
 	 *


### PR DESCRIPTION
This makes it easier to debug Javascript errors deep inside a stack. Only works if Firebug is also installed - if not, the  current behavior will just continue.
