### PR TITLE
fix issue#19: JSErrorCollector is broken with webdriver 2.45.0 and Firefox 36

### DIFF
--- a/firefox/content/overlay.js
+++ b/firefox/content/overlay.js
@@ -6,8 +6,8 @@ var JSErrorCollector = {
 		},
 		pump: function() {
 			var resp = [];
-			for (var i=0; i<this.list.length; ++i) {
-				var scriptError = this.list[i];
+			for (var i=0; i<this.wrappedJSObject.list.length; ++i) {
+				var scriptError = this.wrappedJSObject.list[i];
 				resp[i] = {
 						errorMessage: scriptError.errorMessage,
 						sourceName: scriptError.sourceName,
@@ -15,7 +15,7 @@ var JSErrorCollector = {
 						console: scriptError.console
 						};
 			}
-			this.list = [];
+			this.wrappedJSObject.list = [];
 			return resp;
 		},
 		toString: function() {
@@ -24,8 +24,7 @@ var JSErrorCollector = {
 				s += i + ": " + this.list[i] + "\n";
 			}
 			return s;
-		},
-		__exposedProps__: { pump: "r" }
+		}
 	},
 	onLoad: function(event) {
 	    // initialization code
@@ -44,10 +43,10 @@ var JSErrorCollector = {
 
 		var onPageLoad = function(aEvent) {
 			var doc = aEvent.originalTarget;  
-		    var win = doc.defaultView;
-		    if (win) {
-				win.wrappedJSObject.JSErrorCollector_errors = JSErrorCollector.collectedErrors;
-		    }
+			var win = doc.defaultView;
+			if (win) {
+				win.wrappedJSObject.JSErrorCollector_errors = Components.utils.cloneInto(JSErrorCollector.collectedErrors,win.wrappedJSObject,{cloneFunctions: true});
+			}
 		};
 
 		windowContent.addEventListener("load", onPageLoad, true);

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.jsourcerer.webdriver</groupId>
     <artifactId>JSErrorCollector</artifactId>
-    <version>0.5</version>
+    <version>0.6</version>
     <name>JSErrorCollector</name>
     <organization>
         <name>Marc Guillemot</name>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-firefox-driver</artifactId>
-            <version>2.31.0</version>
+            <version>2.45.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
I fixed the plugin, so that it works in Firefox 36 with new webderiver version. The "__exposedProps__" is no longer supported by Firefox (after long time of being deprecated). 

I consulted some documentation and replaced that construct with other suggested by Mozilla (https://developer.mozilla.org/en-US/docs/Components.utils.cloneInto).