### PR TITLE
Junit fixes

### DIFF
--- a/src/test/java/net/jsourcerer/webdriver/jserrorcollector/SimpleTest.java
+++ b/src/test/java/net/jsourcerer/webdriver/jserrorcollector/SimpleTest.java
@@ -1,17 +1,17 @@
 package net.jsourcerer.webdriver.jserrorcollector;
 
-import org.junit.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxProfile;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxProfile;
 
 
 /**
@@ -40,13 +40,15 @@ public class SimpleTest {
 	@Test
 	public void simple() throws Exception {
 		final WebDriver driver = buildFFDriver();
-		driver.get(urlSimpleHtml);
-		
-		final List<JavaScriptError> expectedErrors = Arrays.asList(errorSimpleHtml);
-		final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
-		assertEquals(expectedErrors, jsErrors);
-		
-		driver.quit();
+		try{
+			driver.get(urlSimpleHtml);
+			
+			final List<JavaScriptError> expectedErrors = Arrays.asList(errorSimpleHtml);
+			final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
+			assertEquals(expectedErrors, jsErrors);
+		}finally{
+			driver.quit();
+		}
 	}
 	
 	/**
@@ -57,12 +59,14 @@ public class SimpleTest {
 		final List<JavaScriptError> expectedErrors = Arrays.asList(errorWithNestedFrameHtml, errorSimpleHtml);
 
 		final WebDriver driver = buildFFDriver();
-		driver.get(urlWithNestedFrameHtml);
-		
-		final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
-		assertEquals(expectedErrors.toString(), jsErrors.toString());
-
-		driver.quit();
+		try{
+			driver.get(urlWithNestedFrameHtml);
+			
+			final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
+			assertEquals(expectedErrors.toString(), jsErrors.toString());
+		}finally{
+			driver.quit();
+		}
 	}
 	
 	/**
@@ -73,13 +77,16 @@ public class SimpleTest {
 		final List<JavaScriptError> expectedErrors = Arrays.asList(errorPopupHtml);
 
 		final WebDriver driver = buildFFDriver();
-		driver.get(urlWithPopupHtml);
-		driver.findElement(By.tagName("button")).click();
-
-		final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
-		assertEquals(expectedErrors.toString(), jsErrors.toString());
-		
-		driver.quit();
+		try{
+			driver.get(urlWithPopupHtml);
+			driver.findElement(By.tagName("button")).click();
+			driver.switchTo().window("The Popup");
+	
+			final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
+			assertEquals(expectedErrors.toString(), jsErrors.toString());
+		}finally{
+			driver.quit();
+		}
 	}
 
 	/**
@@ -90,18 +97,19 @@ public class SimpleTest {
 		final List<JavaScriptError> expectedErrors = Arrays.asList(errorExternalJs);
 
 		final WebDriver driver = buildFFDriver();
-		driver.get(urlWithExternalJs);
-
-		final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
-		assertEquals(expectedErrors.toString(), jsErrors.toString());
-		
-		driver.quit();
+		try{
+			driver.get(urlWithExternalJs);
+	
+			final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
+			assertEquals(expectedErrors.toString(), jsErrors.toString());
+		}finally{
+			driver.quit();
+		}
 	}
 
 	WebDriver buildFFDriver() throws IOException {
 		FirefoxProfile ffProfile = new FirefoxProfile();
 		ffProfile.addExtension(new File("firefox")); // assuming that the test is started in project's root
-
 		return new FirefoxDriver(ffProfile);
 	}
 

--- a/src/test/resources/withPopup.html
+++ b/src/test/resources/withPopup.html
@@ -4,6 +4,6 @@
 </head>
 <body>
 
-<button onclick="window.open('popup.html')">open popup</button>
+<button onclick="window.open('popup.html','The Popup')">open popup</button>
 </body>
 </html>


### PR DESCRIPTION
Corrected:
 - Added try-finally statements so that Firefox window is closed even, when the test fails.
 - Updated net.jsourcerer.webdriver.jserrorcollector.SimpleTest.errorInPopup(). I think webdriver needs to switch to new popup window to detect JS errors there, am I right?

Still not working:
 - net.jsourcerer.webdriver.jserrorcollector.FirebugConsoleTest is failing. Detecting Firebug is not that easy anymore.