### PR TITLE
Also return sourceLine, columnNumber and flags

### DIFF
--- a/firefox/content/overlay.js
+++ b/firefox/content/overlay.js
@@ -11,7 +11,10 @@ var JSErrorCollector = new function() {
 				resp[i] = {
 						errorMessage: scriptError.errorMessage,
 						sourceName: scriptError.sourceName,
+						sourceLine: scriptError.sourceLine,
 						lineNumber: scriptError.lineNumber,
+						columnNumber: scriptError.columnNumber,
+						flags: scriptError.flags,
 						console: scriptError.console
 						};
 			}
@@ -109,7 +112,10 @@ var JSErrorCollector_ErrorConsoleListener =
                     var err = {
 						errorMessage: scriptError.errorMessage,
 						sourceName: scriptError.sourceName,
+						sourceLine: scriptError.sourceLine,
 						lineNumber: scriptError.lineNumber,
+						columnNumber: scriptError.columnNumber,
+						flags: scriptError.flags,
             			console: consoleContent
             		};
                 	console.log("collecting JS error", err)


### PR DESCRIPTION
This PR exposes the remaining attributes of nsIScriptError (https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIScriptError) - most importantly, `flags` which permits distinguishing errors (technically exceptions) from warnings in the code that uses JSErrorCollector.